### PR TITLE
Release version for people using android.support:v28

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-27.0.3
-    - android-27
-    - doc-27
+    - build-tools-28.0.0
+    - android-28
+    - doc-28
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A handy `CoordinatorLayout` that works well when used in a bottom sheet, even wi
   <img src="art/bottom1.gif" width="250" vspace="20">
 </p>
 
+*Having issues with android.support v28? Please try `com.otaliastudios:bottomsheetcoordinatorlayout:1.1.0-RC1`.*
+
 ## Usage
 
 Just use `BottomSheetCoordinatorLayout` as the root view of your bottom sheet. It will be automatically

--- a/build.gradle
+++ b/build.gradle
@@ -6,11 +6,11 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.2.0-beta04'
         // https://inthecheesefactory.com/blog/how-to-upload-library-to-jcenter-maven-central-as-dependency/en
         // https://www.theguardian.com/technology/developer-blog/2016/dec/06/how-to-publish-an-android-library-a-mysterious-conversation
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
     }
 }
 
@@ -23,11 +23,11 @@ allprojects {
 
 ext {
     // Updating: check travis
-    compileSdkVersion = 27
-    buildToolsVersion = "27.0.3"
-    supportLibVersion = '27.1.0'
+    compileSdkVersion = 28
+    buildToolsVersion = "28.0.0"
+    supportLibVersion = '28.0.0-beta01'
     minSdkVersion = 14
-    targetSdkVersion = 27
+    targetSdkVersion = 28
 }
 
 task clean(type: Delete) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.jfrog.bintray'
 // Required by bintray
 // archivesBaseName is required if artifactId is different from gradle module name
 // or you can add baseName to each archive task (sources, javadoc, aar)
-version = '1.0.4'
+version = '1.1.0-RC1'
 group = 'com.otaliastudios'
 archivesBaseName = 'bottomsheetcoordinatorlayout'
 


### PR DESCRIPTION
v28 messes up with the setDragCallback method.

- If you use `androidx:v28` with Jetifier, everything should be ok.
- If for some reason you use `android.support:v28`, the app will crash at runtime.

Going to release a specific v28 version to address this. When v28 goes out of beta, we will move to androidx directly.