### PR TITLE
Remove `final` modifier from BottomSheetCoordinatorLayout

### DIFF
--- a/library/src/main/java/com/otaliastudios/bottomsheetcoordinatorlayout/BottomSheetCoordinatorLayout.java
+++ b/library/src/main/java/com/otaliastudios/bottomsheetcoordinatorlayout/BottomSheetCoordinatorLayout.java
@@ -28,7 +28,7 @@ import android.widget.ScrollView;
  * for window insets and app bar layout dragging.
  */
 @CoordinatorLayout.DefaultBehavior(BottomSheetCoordinatorBehavior.class)
-public final class BottomSheetCoordinatorLayout extends CoordinatorLayout implements
+public class BottomSheetCoordinatorLayout extends CoordinatorLayout implements
         AppBarLayout.OnOffsetChangedListener {
 
     private static final String TAG = BottomSheetCoordinatorLayout.class.getSimpleName();


### PR DESCRIPTION
Hey,

Simple PR to remove the `final` keyword unless you have a good reason to use it.
I need this library in my app but my View extends CoordinatorLayout, so if I am to use your CoordinatorLayout instead, I need it to be extendable.